### PR TITLE
Make it easy to use this in cross-compiled projects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["allocator", "no_std", "kernel"]
 
 repository = "https://github.com/phil-opp/rust_allocator_stub"
 
+[lib]
+name = "alloc_system"
+
 [features]
 
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,11 @@ keywords = ["allocator", "no_std", "kernel"]
 
 repository = "https://github.com/phil-opp/rust_allocator_stub"
 
+[features]
+
+default = []
+
+cross-compile = ["rust-libcore"]
+
 [dependencies]
+rust-libcore = {version = "*", optional = true}


### PR DESCRIPTION
This is a very useful crate for `no_std` projects. If we are cross-compiling, though, we want to induce cargo to rebuild libcore and cause this crate to use the cross-compiled libcore. By adding this optional dependency, the crate maintains its existing functionality by default. And those who want to cross-compile can simply use the `cross-compile` feature in their `Cargo.toml`.